### PR TITLE
Unify testing.

### DIFF
--- a/pkg/controller/servicebindingrequest/annotations_test.go
+++ b/pkg/controller/servicebindingrequest/annotations_test.go
@@ -3,7 +3,7 @@ package servicebindingrequest
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -12,10 +12,10 @@ import (
 )
 
 func TestAnnotationsExtractNamespacedName(t *testing.T) {
-	assert.Equal(t, types.NamespacedName{}, extractSBRNamespacedName(map[string]string{}))
+	require.Equal(t, types.NamespacedName{}, extractSBRNamespacedName(map[string]string{}))
 
 	data := map[string]string{sbrNamespaceAnnotation: "ns", sbrNameAnnotation: "name"}
-	assert.Equal(t, types.NamespacedName{Namespace: "ns", Name: "name"}, extractSBRNamespacedName(data))
+	require.Equal(t, types.NamespacedName{Namespace: "ns", Name: "name"}, extractSBRNamespacedName(data))
 }
 
 func TestAnnotationsGetSBRNamespacedNameFromObject(t *testing.T) {
@@ -25,16 +25,16 @@ func TestAnnotationsGetSBRNamespacedNameFromObject(t *testing.T) {
 	// not containing annotations, should return empty
 	t.Run("returns-empty", func(t *testing.T) {
 		namespacedName, err := GetSBRNamespacedNameFromObject(u.DeepCopyObject())
-		assert.Nil(t, err)
-		assert.Equal(t, types.NamespacedName{}, namespacedName)
+		require.NoError(t, err)
+		require.Equal(t, types.NamespacedName{}, namespacedName)
 	})
 
 	// with annotations in place it should return the actual values
 	t.Run("from-annotations", func(t *testing.T) {
 		u.SetAnnotations(map[string]string{sbrNamespaceAnnotation: "ns", sbrNameAnnotation: "name"})
 		namespacedName, err := GetSBRNamespacedNameFromObject(u.DeepCopyObject())
-		assert.Nil(t, err)
-		assert.Equal(t, types.NamespacedName{Namespace: "ns", Name: "name"}, namespacedName)
+		require.NoError(t, err)
+		require.Equal(t, types.NamespacedName{Namespace: "ns", Name: "name"}, namespacedName)
 	})
 
 	// it should also understand a actual SBR as well, so return not empty
@@ -44,7 +44,7 @@ func TestAnnotationsGetSBRNamespacedNameFromObject(t *testing.T) {
 		sbr.SetNamespace("ns")
 		sbr.SetName("name")
 		namespacedName, err := GetSBRNamespacedNameFromObject(sbr.DeepCopyObject())
-		assert.Nil(t, err)
-		assert.Equal(t, types.NamespacedName{Namespace: "ns", Name: "name"}, namespacedName)
+		require.NoError(t, err)
+		require.Equal(t, types.NamespacedName{Namespace: "ns", Name: "name"}, namespacedName)
 	})
 }

--- a/pkg/controller/servicebindingrequest/bind_custom_resources_test.go
+++ b/pkg/controller/servicebindingrequest/bind_custom_resources_test.go
@@ -4,7 +4,7 @@ import (
 	v12 "github.com/openshift/api/route/v1"
 	pgv1alpha1 "github.com/operator-backing-service-samples/postgresql-operator/pkg/apis/postgresql/v1alpha1"
 	"github.com/redhat-developer/service-binding-operator/test/mocks"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,11 +27,11 @@ func TestBindNonBindableResources_GetOwnedResources(t *testing.T) {
 	configMap := mocks.ConfigMapMock("test", "test_database")
 	us := &unstructured.Unstructured{}
 	uc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&configMap)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	us.Object = uc
 	us.SetOwnerReferences([]v1.OwnerReference{reference})
 	route, err := runtime.DefaultUnstructuredConverter.ToUnstructured(mocks.RouteCRMock("test", "test"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	usRoute := &unstructured.Unstructured{Object: route}
 	usRoute.SetOwnerReferences([]v1.OwnerReference{reference})
 	f.S.AddKnownTypes(pgv1alpha1.SchemeGroupVersion, &pgv1alpha1.Database{})
@@ -62,13 +62,13 @@ func TestBindNonBindableResources_GetOwnedResources(t *testing.T) {
 
 	t.Run("Should return configmap as owned resource", func(t *testing.T) {
 		resources, err := b.GetOwnedResources()
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(resources), "Should return 1 owned resource")
+		require.NoError(t, err)
+		require.Equal(t, 2, len(resources), "Should return 1 owned resource")
 	})
 
 	t.Run("Should return all variables exist in the configmap data section", func(t *testing.T) {
 		data, err := b.GetBindableVariables()
-		assert.NoError(t, err)
-		assert.Equal(t, 3, len(data), "")
+		require.NoError(t, err)
+		require.Equal(t, 3, len(data), "")
 	})
 }

--- a/pkg/controller/servicebindingrequest/binder_test.go
+++ b/pkg/controller/servicebindingrequest/binder_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	ustrv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -55,14 +54,14 @@ func TestBinderNew(t *testing.T) {
 
 	t.Run("search target object by resource name", func(t *testing.T) {
 		list, err := binderForSBRWithResourceRef.search()
-		assert.Nil(t, err)
-		assert.Equal(t, 1, len(list.Items))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(list.Items))
 	})
 
 	t.Run("search", func(t *testing.T) {
 		list, err := binder.search()
-		assert.Nil(t, err)
-		assert.Equal(t, 1, len(list.Items))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(list.Items))
 	})
 
 	t.Run("appendEnvFrom", func(t *testing.T) {
@@ -70,47 +69,47 @@ func TestBinderNew(t *testing.T) {
 		d := mocks.DeploymentMock("binder", "binder", map[string]string{})
 		list := binder.appendEnvFrom(d.Spec.Template.Spec.Containers[0].EnvFrom, secretName)
 
-		assert.Equal(t, 1, len(list))
-		assert.Equal(t, secretName, list[0].SecretRef.Name)
+		require.Equal(t, 1, len(list))
+		require.Equal(t, secretName, list[0].SecretRef.Name)
 	})
 
 	t.Run("appendEnv", func(t *testing.T) {
 		d := mocks.DeploymentMock("binder", "binder", map[string]string{})
 		list := binder.appendEnvVar(d.Spec.Template.Spec.Containers[0].Env, "name", "value")
-		assert.Equal(t, 1, len(list))
-		assert.Equal(t, "name", list[0].Name)
-		assert.Equal(t, "value", list[0].Value)
+		require.Equal(t, 1, len(list))
+		require.Equal(t, "name", list[0].Name)
+		require.Equal(t, "value", list[0].Value)
 	})
 
 	t.Run("update", func(t *testing.T) {
 		list, err := binder.search()
-		assert.NoError(t, err)
-		assert.Equal(t, 1, len(list.Items))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(list.Items))
 
 		updatedObjects, err := binder.update(list)
-		assert.NoError(t, err)
-		assert.Len(t, updatedObjects, 1)
+		require.NoError(t, err)
+		require.Len(t, updatedObjects, 1)
 
 		containersPath := []string{"spec", "template", "spec", "containers"}
 		containers, found, err := ustrv1.NestedSlice(list.Items[0].Object, containersPath...)
-		assert.NoError(t, err)
-		assert.True(t, found)
-		assert.Len(t, containers, 1)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Len(t, containers, 1)
 
 		c := corev1.Container{}
 		u := containers[0].(map[string]interface{})
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(u, &c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// ServiceBindingOperatorChangeTriggerEnvVar should exist to trigger a side effect such as Pod restart when the
 		// intermediate secret has been modified
 		envVar := getEnvVar(c.Env, ServiceBindingOperatorChangeTriggerEnvVar)
-		assert.NotNil(t, envVar)
-		assert.NotEmpty(t, envVar.Value)
+		require.NotNil(t, envVar)
+		require.NotEmpty(t, envVar.Value)
 
 		parsedTime, err := time.Parse(time.RFC3339, envVar.Value)
-		assert.NoError(t, err)
-		assert.True(t, parsedTime.Before(time.Now()))
+		require.NoError(t, err)
+		require.True(t, parsedTime.Before(time.Now()))
 	})
 }
 
@@ -163,8 +162,8 @@ func TestBinderApplicationName(t *testing.T) {
 
 	t.Run("search by application name", func(t *testing.T) {
 		list, err := binder.search()
-		assert.Nil(t, err)
-		assert.Equal(t, 1, len(list.Items))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(list.Items))
 	})
 
 }

--- a/pkg/controller/servicebindingrequest/custom_env_parser_test.go
+++ b/pkg/controller/servicebindingrequest/custom_env_parser_test.go
@@ -2,7 +2,7 @@ package servicebindingrequest
 
 import (
 	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -36,7 +36,7 @@ func TestCustomEnvPath_Parse(t *testing.T) {
 		t.Fail()
 	}
 	str := values["JDBC_CONNECTION_STRING"]
-	assert.Equal(t, "database-name:database-user@database-pass", str, "Connection string is not matching")
+	require.Equal(t, "database-name:database-user@database-pass", str, "Connection string is not matching")
 	str2 := values["ANOTHER_STRING"]
-	assert.Equal(t, "database-name_database-user", str2, "Connection string is not matching")
+	require.Equal(t, "database-name_database-user", str2, "Connection string is not matching")
 }

--- a/pkg/controller/servicebindingrequest/mapper_test.go
+++ b/pkg/controller/servicebindingrequest/mapper_test.go
@@ -3,7 +3,6 @@ package servicebindingrequest
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,7 +33,7 @@ func TestSBRRequestMapperMap(t *testing.T) {
 	mapObj = handler.MapObject{Meta: u, Object: u.DeepCopyObject()}
 	mappedRequests = mapper.Map(mapObj)
 	require.Equal(t, 1, len(mappedRequests))
-	assert.Equal(t, request, mappedRequests[0])
+	require.Equal(t, request, mappedRequests[0])
 
 	// it should also understand a actual SBR as well, so return not empty
 	sbr := &unstructured.Unstructured{}
@@ -44,5 +43,5 @@ func TestSBRRequestMapperMap(t *testing.T) {
 	mapObj = handler.MapObject{Meta: u, Object: sbr.DeepCopyObject()}
 	mappedRequests = mapper.Map(mapObj)
 	require.Equal(t, 1, len(mappedRequests))
-	assert.Equal(t, request, mappedRequests[0])
+	require.Equal(t, request, mappedRequests[0])
 }

--- a/pkg/controller/servicebindingrequest/namespacedname_test.go
+++ b/pkg/controller/servicebindingrequest/namespacedname_test.go
@@ -3,13 +3,13 @@ package servicebindingrequest
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestNamespacednameIsSBRNamespacedNameEmpty(t *testing.T) {
-	assert.True(t, IsNamespacedNameEmpty(types.NamespacedName{}))
-	assert.True(t, IsNamespacedNameEmpty(types.NamespacedName{Namespace: "ns"}))
-	assert.True(t, IsNamespacedNameEmpty(types.NamespacedName{Name: "name"}))
-	assert.False(t, IsNamespacedNameEmpty(types.NamespacedName{Namespace: "ns", Name: "name"}))
+	require.True(t, IsNamespacedNameEmpty(types.NamespacedName{}))
+	require.True(t, IsNamespacedNameEmpty(types.NamespacedName{Namespace: "ns"}))
+	require.True(t, IsNamespacedNameEmpty(types.NamespacedName{Name: "name"}))
+	require.False(t, IsNamespacedNameEmpty(types.NamespacedName{Namespace: "ns", Name: "name"}))
 }

--- a/pkg/controller/servicebindingrequest/olm_test.go
+++ b/pkg/controller/servicebindingrequest/olm_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -20,9 +20,9 @@ func init() {
 func assertGVKs(t *testing.T, gvks []schema.GroupVersionKind) {
 	for _, gvk := range gvks {
 		t.Logf("Inspecting GVK: '%s'", gvk)
-		assert.NotEmpty(t, gvk.Group)
-		assert.NotEmpty(t, gvk.Version)
-		assert.NotEmpty(t, gvk.Kind)
+		require.NotEmpty(t, gvk.Group)
+		require.NotEmpty(t, gvk.Version)
+		require.NotEmpty(t, gvk.Kind)
 	}
 }
 
@@ -37,14 +37,14 @@ func TestOLMNew(t *testing.T) {
 
 	t.Run("listCSVs", func(t *testing.T) {
 		csvs, err := olm.listCSVs()
-		assert.NoError(t, err)
-		assert.Len(t, csvs, 1)
+		require.NoError(t, err)
+		require.Len(t, csvs, 1)
 	})
 
 	t.Run("ListCSVOwnedCRDs", func(t *testing.T) {
 		crds, err := olm.ListCSVOwnedCRDs()
-		assert.NoError(t, err)
-		assert.Len(t, crds, 1)
+		require.NoError(t, err)
+		require.Len(t, crds, 1)
 	})
 
 	t.Run("SelectCRDByGVK", func(t *testing.T) {
@@ -54,24 +54,24 @@ func TestOLMNew(t *testing.T) {
 			Version: mocks.CRDVersion,
 			Kind:    mocks.CRDKind,
 		}, nil)
-		assert.NoError(t, err)
-		assert.NotNil(t, crd)
+		require.NoError(t, err)
+		require.NotNil(t, crd)
 		expectedCRDName := strings.ToLower(fmt.Sprintf("%s.%s", mocks.CRDKind, mocks.CRDName))
-		assert.Equal(t, expectedCRDName, crd.Name)
+		require.Equal(t, expectedCRDName, crd.Name)
 	})
 
 	t.Run("ListCSVOwnedCRDsAsGVKs", func(t *testing.T) {
 		gvks, err := olm.ListCSVOwnedCRDsAsGVKs()
-		assert.NoError(t, err)
-		assert.Len(t, gvks, 1)
+		require.NoError(t, err)
+		require.Len(t, gvks, 1)
 		assertGVKs(t, gvks)
 	})
 
 	t.Run("ListGVKsFromCSVNamespacedName", func(t *testing.T) {
 		namespacedName := types.NamespacedName{Namespace: ns, Name: csvName}
 		gvks, err := olm.ListGVKsFromCSVNamespacedName(namespacedName)
-		assert.NoError(t, err)
-		assert.Len(t, gvks, 1)
+		require.NoError(t, err)
+		require.Len(t, gvks, 1)
 		assertGVKs(t, gvks)
 	})
 }

--- a/pkg/controller/servicebindingrequest/planner_test.go
+++ b/pkg/controller/servicebindingrequest/planner_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
@@ -38,19 +37,19 @@ func TestPlannerNew(t *testing.T) {
 	t.Run("searchCR", func(t *testing.T) {
 		cr, err := planner.searchCR()
 
-		assert.Nil(t, err)
-		assert.NotNil(t, cr)
+		require.NoError(t, err)
+		require.NotNil(t, cr)
 	})
 
 	t.Run("plan", func(t *testing.T) {
 		plan, err := planner.Plan()
 
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, plan)
 		require.NotNil(t, plan.CRDDescription)
 		require.NotNil(t, plan.CR)
-		assert.Equal(t, ns, plan.Ns)
-		assert.Equal(t, name, plan.Name)
+		require.Equal(t, ns, plan.Ns)
+		require.Equal(t, name, plan.Name)
 	})
 }
 
@@ -73,7 +72,7 @@ func TestPlannerAnnotation(t *testing.T) {
 	t.Run("searchCRD", func(t *testing.T) {
 		crd, err := planner.searchCRD()
 
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, crd)
 	})
 }

--- a/pkg/controller/servicebindingrequest/reconciler_test.go
+++ b/pkg/controller/servicebindingrequest/reconciler_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -55,11 +54,11 @@ func TestReconcilerReconcileError(t *testing.T) {
 	// references to objects that do not exist, the reconciliation process is supposed to be
 	// successful. Commented below was the original test.
 	//
-	// assert.Error(t, err)
-	// assert.True(t, res.Requeue)
+	// require.Error(t, err)
+	// require.True(t, res.Requeue)
 
-	assert.Nil(t, err)
-	assert.True(t, res.Requeue)
+	require.NoError(t, err)
+	require.True(t, res.Requeue)
 }
 
 // TestApplicationSelectorByName tests discovery of application by name
@@ -81,8 +80,8 @@ func TestApplicationSelectorByName(t *testing.T) {
 	t.Run("test-application-selector-by-name", func(t *testing.T) {
 
 		res, err := reconciler.Reconcile(reconcileRequest())
-		assert.NoError(t, err)
-		assert.False(t, res.Requeue)
+		require.NoError(t, err)
+		require.False(t, res.Requeue)
 
 		namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
 		sbrOutput, err := reconciler.getServiceBindingRequest(namespacedName)
@@ -91,7 +90,7 @@ func TestApplicationSelectorByName(t *testing.T) {
 		require.Equal(t, "Success", sbrOutput.Status.BindingStatus)
 		require.Equal(t, 1, len(sbrOutput.Status.ApplicationObjects))
 		expectedStatus := fmt.Sprintf("%s/%s", reconcilerNs, reconcilerName)
-		assert.Equal(t, expectedStatus, sbrOutput.Status.ApplicationObjects[0])
+		require.Equal(t, expectedStatus, sbrOutput.Status.ApplicationObjects[0])
 	})
 }
 
@@ -119,18 +118,18 @@ func TestReconcilerReconcileUsingSecret(t *testing.T) {
 
 	t.Run("reconcile-using-secret", func(t *testing.T) {
 		res, err := reconciler.Reconcile(reconcileRequest())
-		assert.Nil(t, err)
-		assert.False(t, res.Requeue)
+		require.NoError(t, err)
+		require.False(t, res.Requeue)
 
 		namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
 		d := appsv1.Deployment{}
-		require.Nil(t, fakeClient.Get(ctx, namespacedName, &d))
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &d))
 
 		containers := d.Spec.Template.Spec.Containers
 		require.Equal(t, 1, len(containers))
 		require.Equal(t, 1, len(containers[0].EnvFrom))
-		assert.NotNil(t, containers[0].EnvFrom[0].SecretRef)
-		assert.Equal(t, reconcilerName, containers[0].EnvFrom[0].SecretRef.Name)
+		require.NotNil(t, containers[0].EnvFrom[0].SecretRef)
+		require.Equal(t, reconcilerName, containers[0].EnvFrom[0].SecretRef.Name)
 
 		namespacedName = types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
 		sbrOutput, err := reconciler.getServiceBindingRequest(namespacedName)
@@ -141,7 +140,7 @@ func TestReconcilerReconcileUsingSecret(t *testing.T) {
 
 		require.Equal(t, 1, len(sbrOutput.Status.ApplicationObjects))
 		expectedStatus := fmt.Sprintf("%s/%s", reconcilerNs, reconcilerName)
-		assert.Equal(t, expectedStatus, sbrOutput.Status.ApplicationObjects[0])
+		require.Equal(t, expectedStatus, sbrOutput.Status.ApplicationObjects[0])
 	})
 }
 
@@ -166,22 +165,22 @@ func TestReconcilerReconcileUsingVolumes(t *testing.T) {
 
 	t.Run("reconcile-using-volume", func(t *testing.T) {
 		res, err := reconciler.Reconcile(reconcileRequest())
-		assert.Nil(t, err)
-		assert.False(t, res.Requeue)
+		require.NoError(t, err)
+		require.False(t, res.Requeue)
 
 		namespacedName := types.NamespacedName{Namespace: reconcilerNs, Name: reconcilerName}
 		d := appsv1.Deployment{}
-		require.Nil(t, fakeClient.Get(ctx, namespacedName, &d))
+		require.NoError(t, fakeClient.Get(ctx, namespacedName, &d))
 
 		containers := d.Spec.Template.Spec.Containers
 
 		require.Equal(t, 1, len(containers[0].VolumeMounts))
-		assert.Equal(t, "/var/redhat", containers[0].VolumeMounts[0].MountPath)
-		assert.Equal(t, reconcilerName, containers[0].VolumeMounts[0].Name)
+		require.Equal(t, "/var/redhat", containers[0].VolumeMounts[0].MountPath)
+		require.Equal(t, reconcilerName, containers[0].VolumeMounts[0].Name)
 
 		volumes := d.Spec.Template.Spec.Volumes
 		require.Equal(t, 1, len(volumes))
-		assert.Equal(t, reconcilerName, volumes[0].Name)
-		assert.Equal(t, reconcilerName, volumes[0].VolumeSource.Secret.SecretName)
+		require.Equal(t, reconcilerName, volumes[0].Name)
+		require.Equal(t, reconcilerName, volumes[0].VolumeSource.Secret.SecretName)
 	})
 }

--- a/pkg/controller/servicebindingrequest/retriever_test.go
+++ b/pkg/controller/servicebindingrequest/retriever_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
@@ -25,7 +24,7 @@ func TestRetriever(t *testing.T) {
 
 	crdDescription := mocks.CRDDescriptionMock()
 	cr, err := mocks.UnstructuredDatabaseCRMock(ns, crName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	plan := &Plan{Ns: ns, Name: "retriever", CRDDescription: &crdDescription, CR: cr}
 
@@ -36,15 +35,15 @@ func TestRetriever(t *testing.T) {
 
 	t.Run("retrive", func(t *testing.T) {
 		objs, err := retriever.Retrieve()
-		assert.Nil(t, err)
-		assert.NotEmpty(t, retriever.data)
-		assert.True(t, len(objs) > 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, retriever.data)
+		require.True(t, len(objs) > 0)
 	})
 
 	t.Run("getCRKey", func(t *testing.T) {
 		imageName, _, err := retriever.getCRKey("spec", "imageName")
-		assert.Nil(t, err)
-		assert.Equal(t, "postgres", imageName)
+		require.NoError(t, err)
+		require.Equal(t, "postgres", imageName)
 	})
 
 	t.Run("read", func(t *testing.T) {
@@ -53,25 +52,25 @@ func TestRetriever(t *testing.T) {
 			"binding:env:object:secret:user",
 			"binding:env:object:secret:password",
 		})
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		t.Logf("retriever.data '%#v'", retriever.data)
-		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
-		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
 
 		// reading from spec attribute
 		err = retriever.read("spec", "image", []string{
 			"binding:env:attribute",
 		})
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		t.Logf("retriever.data '%#v'", retriever.data)
-		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_IMAGE")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_IMAGE")
 
 	})
 
 	t.Run("extractSecretItemName", func(t *testing.T) {
-		assert.Equal(t, "user", retriever.extractSecretItemName(
+		require.Equal(t, "user", retriever.extractSecretItemName(
 			"binding:env:object:secret:user"))
 	})
 
@@ -79,21 +78,21 @@ func TestRetriever(t *testing.T) {
 		retriever.data = make(map[string][]byte)
 
 		err := retriever.readSecret("db-credentials", []string{"user", "password"}, "spec", "dbConfigMap")
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
-		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
-		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_USER")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_SECRET_PASSWORD")
 	})
 
 	t.Run("store", func(t *testing.T) {
 		retriever.store("test", []byte("test"))
-		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_TEST")
-		assert.Equal(t, []byte("test"), retriever.data["SERVICE_BINDING_DATABASE_TEST"])
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_TEST")
+		require.Equal(t, []byte("test"), retriever.data["SERVICE_BINDING_DATABASE_TEST"])
 	})
 
 	t.Run("saveDataOnSecret", func(t *testing.T) {
 		err := retriever.saveDataOnSecret()
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("empty prefix", func(t *testing.T) {
@@ -102,10 +101,10 @@ func TestRetriever(t *testing.T) {
 		retriever.data = make(map[string][]byte)
 
 		err := retriever.readSecret("db-credentials", []string{"user", "password"}, "spec", "dbConfigMap")
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
-		assert.Contains(t, retriever.data, "DATABASE_SECRET_USER")
-		assert.Contains(t, retriever.data, "DATABASE_SECRET_PASSWORD")
+		require.Contains(t, retriever.data, "DATABASE_SECRET_USER")
+		require.Contains(t, retriever.data, "DATABASE_SECRET_PASSWORD")
 	})
 }
 
@@ -122,7 +121,7 @@ func TestRetrieverWithNestedCRKey(t *testing.T) {
 
 	crdDescription := mocks.CRDDescriptionMock()
 	cr, err := mocks.UnstructuredNestedDatabaseCRMock(ns, crName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	plan := &Plan{Ns: ns, Name: "retriever", CRDDescription: &crdDescription, CR: cr}
 
@@ -133,21 +132,21 @@ func TestRetrieverWithNestedCRKey(t *testing.T) {
 
 	t.Run("Second level", func(t *testing.T) {
 		imageName, _, err := retriever.getCRKey("spec", "image.name")
-		assert.Nil(t, err)
-		assert.Equal(t, "postgres", imageName)
+		require.NoError(t, err)
+		require.Equal(t, "postgres", imageName)
 	})
 
 	t.Run("Second level error", func(t *testing.T) {
 		// FIXME: if attribute isn't available in CR we would not throw any error.
 		t.Skip()
 		_, _, err := retriever.getCRKey("spec", "image..name")
-		assert.NotNil(t, err)
+		require.NotNil(t, err)
 	})
 
 	t.Run("Third level", func(t *testing.T) {
 		something, _, err := retriever.getCRKey("spec", "image.third.something")
-		assert.Nil(t, err)
-		assert.Equal(t, "somevalue", something)
+		require.NoError(t, err)
+		require.Equal(t, "somevalue", something)
 	})
 
 }
@@ -167,7 +166,7 @@ func TestRetrieverWithConfigMap(t *testing.T) {
 	crdDescription := mocks.CRDDescriptionConfigMapMock()
 
 	cr, err := mocks.UnstructuredDatabaseConfigMapMock(ns, crName, crName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	plan := &Plan{Ns: ns, Name: "retriever", CRDDescription: &crdDescription, CR: cr}
 
@@ -182,15 +181,15 @@ func TestRetrieverWithConfigMap(t *testing.T) {
 			"binding:env:object:configmap:user",
 			"binding:env:object:configmap:password",
 		})
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		t.Logf("retriever.data '%#v'", retriever.data)
-		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_CONFIGMAP_USER")
-		assert.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_CONFIGMAP_PASSWORD")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_CONFIGMAP_USER")
+		require.Contains(t, retriever.data, "SERVICE_BINDING_DATABASE_CONFIGMAP_PASSWORD")
 	})
 
 	t.Run("extractConfigMapItemName", func(t *testing.T) {
-		assert.Equal(t, "user", retriever.extractConfigMapItemName(
+		require.Equal(t, "user", retriever.extractConfigMapItemName(
 			"binding:env:object:configmap:user"))
 	})
 
@@ -198,10 +197,10 @@ func TestRetrieverWithConfigMap(t *testing.T) {
 		retriever.data = make(map[string][]byte)
 
 		err := retriever.readConfigMap(crName, []string{"user", "password"}, "spec", "dbConfigMap")
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
-		assert.Contains(t, retriever.data, ("SERVICE_BINDING_DATABASE_CONFIGMAP_USER"))
-		assert.Contains(t, retriever.data, ("SERVICE_BINDING_DATABASE_CONFIGMAP_PASSWORD"))
+		require.Contains(t, retriever.data, ("SERVICE_BINDING_DATABASE_CONFIGMAP_USER"))
+		require.Contains(t, retriever.data, ("SERVICE_BINDING_DATABASE_CONFIGMAP_PASSWORD"))
 	})
 
 }
@@ -219,7 +218,7 @@ func TestCustomEnvParser(t *testing.T) {
 
 	crdDescription := mocks.CRDDescriptionMock()
 	cr, err := mocks.UnstructuredDatabaseCRMock(ns, crName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	plan := &Plan{Ns: ns, Name: "retriever", CRDDescription: &crdDescription, CR: cr}
 
@@ -230,7 +229,7 @@ func TestCustomEnvParser(t *testing.T) {
 
 	t.Run("Should detect custom env values", func(t *testing.T) {
 		_, err = retriever.Retrieve()
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		t.Logf("\nCache %+v", retriever.cache)
 
@@ -250,7 +249,7 @@ func TestCustomEnvParser(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		assert.Equal(t, "dXNlcg==_cGFzc3dvcmQ=", values["ANOTHER_STRING"], "Custom env values are not matching")
-		assert.Equal(t, "postgres@cGFzc3dvcmQ=", values["JDBC_CONNECTION_STRING"], "Custom env values are not matching")
+		require.Equal(t, "dXNlcg==_cGFzc3dvcmQ=", values["ANOTHER_STRING"], "Custom env values are not matching")
+		require.Equal(t, "postgres@cGFzc3dvcmQ=", values["JDBC_CONNECTION_STRING"], "Custom env values are not matching")
 	})
 }

--- a/test/e2e/servicebindingrequest_test.go
+++ b/test/e2e/servicebindingrequest_test.go
@@ -13,7 +13,6 @@ import (
 	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -400,7 +399,7 @@ func serviceBindingRequestTest(t *testing.T, ctx *framework.TestCtx, f *framewor
 		return err
 	})
 	t.Logf("Deployment: Result after attempts, error: '%#v'", err)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// checking intermediary secret contents, right after deployment the secrets must be in place
 	intermediarySecretNamespacedName := types.NamespacedName{Namespace: ns, Name: name}
@@ -424,7 +423,7 @@ func serviceBindingRequestTest(t *testing.T, ctx *framework.TestCtx, f *framewor
 		return err
 	})
 	t.Logf("Intermediary-Secret: Result after attempts, error: '%#v'", err)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// cleaning up
 	t.Log("Cleaning all up!")

--- a/test/mocks/fake.go
+++ b/test/mocks/fake.go
@@ -41,7 +41,6 @@ func (f *Fake) AddMockedServiceBindingRequest(
 	return sbr
 }
 
-
 // AddMockedServiceBindingRequestWithUnannotated add mocked object from ServiceBindingRequestMock with DetectBindingResources.
 func (f *Fake) AddMockedServiceBindingRequestWithUnannotated(
 	name string,
@@ -63,30 +62,30 @@ func (f *Fake) AddMockedUnstructuredServiceBindingRequest(
 ) *unstructured.Unstructured {
 	f.S.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.ServiceBindingRequest{})
 	sbr, err := UnstructuredServiceBindingRequestMock(f.ns, name, backingServiceResourceRef, applicationResourceRef, matchLabels)
-	require.Nil(f.t, err)
+	require.NoError(f.t, err)
 	f.objs = append(f.objs, sbr)
 	return sbr
 }
 
 // AddMockedUnstructuredCSV add mocked unstructured CSV.
 func (f *Fake) AddMockedUnstructuredCSV(name string) {
-	require.Nil(f.t, olmv1alpha1.AddToScheme(f.S))
+	require.NoError(f.t, olmv1alpha1.AddToScheme(f.S))
 	csv, err := UnstructuredClusterServiceVersionMock(f.ns, name)
-	require.Nil(f.t, err)
+	require.NoError(f.t, err)
 	f.S.AddKnownTypes(olmv1alpha1.SchemeGroupVersion, &olmv1alpha1.ClusterServiceVersion{})
 	f.objs = append(f.objs, csv)
 }
 
 // AddMockedCSVList add mocked object from ClusterServiceVersionListMock.
 func (f *Fake) AddMockedCSVList(name string) {
-	require.Nil(f.t, olmv1alpha1.AddToScheme(f.S))
+	require.NoError(f.t, olmv1alpha1.AddToScheme(f.S))
 	f.S.AddKnownTypes(olmv1alpha1.SchemeGroupVersion, &olmv1alpha1.ClusterServiceVersion{})
 	f.objs = append(f.objs, ClusterServiceVersionListMock(f.ns, name))
 }
 
 // AddMockedCSVWithVolumeMountList add mocked object from ClusterServiceVersionListVolumeMountMock.
 func (f *Fake) AddMockedCSVWithVolumeMountList(name string) {
-	require.Nil(f.t, olmv1alpha1.AddToScheme(f.S))
+	require.NoError(f.t, olmv1alpha1.AddToScheme(f.S))
 	f.S.AddKnownTypes(olmv1alpha1.SchemeGroupVersion, &olmv1alpha1.ClusterServiceVersion{})
 	f.objs = append(f.objs, ClusterServiceVersionListVolumeMountMock(f.ns, name))
 }
@@ -94,47 +93,47 @@ func (f *Fake) AddMockedCSVWithVolumeMountList(name string) {
 // AddMockedUnstructuredCSVWithVolumeMount same than AddMockedCSVWithVolumeMountList but using
 // unstructured object.
 func (f *Fake) AddMockedUnstructuredCSVWithVolumeMount(name string) {
-	require.Nil(f.t, olmv1alpha1.AddToScheme(f.S))
+	require.NoError(f.t, olmv1alpha1.AddToScheme(f.S))
 	csv, err := UnstructuredClusterServiceVersionVolumeMountMock(f.ns, name)
-	require.Nil(f.t, err)
+	require.NoError(f.t, err)
 	f.S.AddKnownTypes(olmv1alpha1.SchemeGroupVersion, &olmv1alpha1.ClusterServiceVersion{})
 	f.objs = append(f.objs, csv)
 }
 
 // AddMockedDatabaseCR add mocked object from DatabaseCRMock.
 func (f *Fake) AddMockedDatabaseCR(ref string) {
-	require.Nil(f.t, pgapis.AddToScheme(f.S))
+	require.NoError(f.t, pgapis.AddToScheme(f.S))
 	f.S.AddKnownTypes(pgv1alpha1.SchemeGroupVersion, &pgv1alpha1.Database{})
 	f.objs = append(f.objs, DatabaseCRMock(f.ns, ref))
 }
 
 func (f *Fake) AddMockedUnstructuredDatabaseCR(ref string) {
-	require.Nil(f.t, pgapis.AddToScheme(f.S))
+	require.NoError(f.t, pgapis.AddToScheme(f.S))
 	d, err := UnstructuredDatabaseCRMock(f.ns, ref)
-	require.Nil(f.t, err)
+	require.NoError(f.t, err)
 	f.objs = append(f.objs, d)
 }
 
 // AddMockedUnstructuredDeployment add mocked object from UnstructuredDeploymentMock.
 func (f *Fake) AddMockedUnstructuredDeployment(name string, matchLabels map[string]string) {
-	require.Nil(f.t, appsv1.AddToScheme(f.S))
+	require.NoError(f.t, appsv1.AddToScheme(f.S))
 	d, err := UnstructuredDeploymentMock(f.ns, name, matchLabels)
-	require.Nil(f.t, err)
+	require.NoError(f.t, err)
 	f.S.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.Deployment{})
 	f.objs = append(f.objs, d)
 }
 
 func (f *Fake) AddMockedUnstructuredDatabaseCRD() {
-	require.Nil(f.t, apiextensionv1beta1.AddToScheme(f.S))
+	require.NoError(f.t, apiextensionv1beta1.AddToScheme(f.S))
 	c, err := UnstructuredDatabaseCRDMock(f.ns)
-	require.Nil(f.t, err)
+	require.NoError(f.t, err)
 	f.S.AddKnownTypes(apiextensionv1beta1.SchemeGroupVersion, &apiextensionv1beta1.CustomResourceDefinition{})
 	f.objs = append(f.objs, c)
 }
 
 func (f *Fake) AddMockedUnstructuredPostgresDatabaseCR(ref string) {
 	d, err := UnstructuredPostgresDatabaseCRMock(f.ns, ref)
-	require.Nil(f.t, err)
+	require.NoError(f.t, err)
 	f.objs = append(f.objs, d)
 }
 


### PR DESCRIPTION
`assert`'s functions does not fail the test, it only returns a boolean instead, while `require` does fail the test when the condition is not met.

For example the NotNil function
 * `assert.NotNil()`: https://github.com/stretchr/testify/blob/master/assert/assertions.go#L470
 * `require.NotNil()`: https://github.com/stretchr/testify/blob/master/require/require.go#L1093

So this PR:
 * Replace assert package with require
 * Use require.NoError() instead of require.Nil() wherever error is checked.