### PR TITLE
remove redundant envVarPrefix for serviceContexts

### DIFF
--- a/pkg/controller/servicebindingrequest/reconciler.go
+++ b/pkg/controller/servicebindingrequest/reconciler.go
@@ -135,7 +135,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return NoRequeue(ErrEmptyBackingServiceSelectors)
 	}
 
-	serviceCtxs, err := buildServiceContexts(r.dynClient, sbr.GetNamespace(), selectors, nil)
+	serviceCtxs, err := buildServiceContexts(r.dynClient, sbr.GetNamespace(), selectors)
 	if err != nil {
 		return RequeueError(err)
 	}

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -118,19 +118,6 @@ func (r *Retriever) GetEnvVars() (map[string][]byte, error) {
 		envVars[k] = []byte(v.(string))
 	}
 
-	prefixes := []string{}
-	if r.bindingPrefix != "" {
-		prefixes = append(prefixes, r.bindingPrefix)
-	}
-	svcEnvVars, err := envvars.Build(svcCollectedKeys, prefixes...)
-	if err != nil {
-		return nil, err
-	}
-
-	for k, v := range svcEnvVars {
-		envVars[k] = []byte(v)
-	}
-
 	return envVars, nil
 }
 

--- a/pkg/controller/servicebindingrequest/servicecontext.go
+++ b/pkg/controller/servicebindingrequest/servicecontext.go
@@ -47,11 +47,11 @@ func buildServiceContexts(
 		if s.Namespace == nil {
 			s.Namespace = &ns
 		}
-
+		envVarPrefix := s.EnvVarPrefix
 		gvk := schema.GroupVersionKind{Kind: s.Kind, Version: s.Version, Group: s.Group}
 
 		serviceCtx, err := buildServiceContext(
-			client, *s.Namespace, gvk, s.ResourceRef)
+			client, *s.Namespace, gvk, s.ResourceRef, envVarPrefix)
 		if err != nil {
 			return nil, err
 		}
@@ -66,6 +66,7 @@ func buildServiceContext(
 	ns string,
 	gvk schema.GroupVersionKind,
 	resourceRef string,
+	envVarPrefix *string,
 ) (*ServiceContext, error) {
 	obj, err := findService(client, ns, gvk, resourceRef)
 	if err != nil {
@@ -131,9 +132,10 @@ func buildServiceContext(
 	}
 
 	serviceCtx := &ServiceContext{
-		Object:     obj,
-		EnvVars:    envVars,
-		VolumeKeys: volumeKeys,
+		Object:       obj,
+		EnvVars:      envVars,
+		VolumeKeys:   volumeKeys,
+		EnvVarPrefix: envVarPrefix,
 	}
 
 	return serviceCtx, nil

--- a/pkg/controller/servicebindingrequest/servicecontext.go
+++ b/pkg/controller/servicebindingrequest/servicecontext.go
@@ -41,7 +41,6 @@ func buildServiceContexts(
 	client dynamic.Interface,
 	ns string,
 	selectors []v1alpha1.BackingServiceSelector,
-	envVarPrefix *string,
 ) (ServiceContextList, error) {
 	serviceCtxs := make([]*ServiceContext, 0)
 	for _, s := range selectors {
@@ -52,7 +51,7 @@ func buildServiceContexts(
 		gvk := schema.GroupVersionKind{Kind: s.Kind, Version: s.Version, Group: s.Group}
 
 		serviceCtx, err := buildServiceContext(
-			client, *s.Namespace, gvk, s.ResourceRef, envVarPrefix)
+			client, *s.Namespace, gvk, s.ResourceRef)
 		if err != nil {
 			return nil, err
 		}
@@ -67,7 +66,6 @@ func buildServiceContext(
 	ns string,
 	gvk schema.GroupVersionKind,
 	resourceRef string,
-	envVarPrefix *string,
 ) (*ServiceContext, error) {
 	obj, err := findService(client, ns, gvk, resourceRef)
 	if err != nil {
@@ -133,10 +131,9 @@ func buildServiceContext(
 	}
 
 	serviceCtx := &ServiceContext{
-		Object:       obj,
-		EnvVars:      envVars,
-		VolumeKeys:   volumeKeys,
-		EnvVarPrefix: envVarPrefix,
+		Object:     obj,
+		EnvVars:    envVars,
+		VolumeKeys: volumeKeys,
 	}
 
 	return serviceCtx, nil

--- a/pkg/controller/servicebindingrequest/servicecontext_test.go
+++ b/pkg/controller/servicebindingrequest/servicecontext_test.go
@@ -28,20 +28,20 @@ func TestBuildServiceContexts(t *testing.T) {
 
 	t.Run("existing selectors", func(t *testing.T) {
 		serviceCtxs, err := buildServiceContexts(
-			f.FakeDynClient(), ns, extractServiceSelectors(sbr), nil)
+			f.FakeDynClient(), ns, extractServiceSelectors(sbr))
 		require.NoError(t, err)
 		require.NotEmpty(t, serviceCtxs)
 	})
 
 	t.Run("empty selectors", func(t *testing.T) {
-		serviceCtxs, err := buildServiceContexts(f.FakeDynClient(), ns, nil, nil)
+		serviceCtxs, err := buildServiceContexts(f.FakeDynClient(), ns, nil)
 		require.NoError(t, err)
 		require.Empty(t, serviceCtxs)
 	})
 
 	t.Run("services in different namespace", func(t *testing.T) {
 		serviceCtxs, err := buildServiceContexts(
-			f.FakeDynClient(), ns, extractServiceSelectors(sbr), nil)
+			f.FakeDynClient(), ns, extractServiceSelectors(sbr))
 		require.NoError(t, err)
 		require.NotEmpty(t, serviceCtxs)
 	})


### PR DESCRIPTION
removing envVarPrefix(the global prefix) from each serviceContext. Instead the bindingPrefix from the retriever has been previously used as the global envVarPrefix.